### PR TITLE
Set page title when the query changes

### DIFF
--- a/src/issuesof.net/Pages/Index.razor.cs
+++ b/src/issuesof.net/Pages/Index.razor.cs
@@ -105,6 +105,7 @@ namespace IssuesOfDotNet.Pages
             SearchResults = Find(searchText);
             PageNumber = 1;
             ChangeUrl();
+            ChangeTitle();
             StateHasChanged();
         }
 
@@ -143,6 +144,17 @@ namespace IssuesOfDotNet.Pages
                                             uri.ToString(),
                                             /* forceLoad */ false,
                                             /* replace */ true);
+        }
+
+        private async void ChangeTitle()
+        {
+            var isDefaultQuery = (string.IsNullOrEmpty(_searchText) ||
+                                  _searchText.Trim() == _defaultSearch) &&
+                                  PageNumber <= 1;
+
+            var pageTitle = isDefaultQuery ? "Issues of .NET" : $"Issues of .NET ({_searchText})";
+
+            await JSRuntime.InvokeVoidAsync("setPageTitle", pageTitle);
         }
 
         private void CollapseAll()

--- a/src/issuesof.net/Pages/_Host.cshtml
+++ b/src/issuesof.net/Pages/_Host.cshtml
@@ -134,7 +134,11 @@
                 return json;
             });
         }
-
+        
+        function setPageTitle(pageTitle) {
+            document.title = pageTitle;
+        }
+        
         var observer = new MutationObserver(function (mutations, observer) {
             var codeMirror = document.querySelector('.CodeMirror');
             var myTextarea = document.querySelector('#myTextarea');


### PR DESCRIPTION
Fixes #9 by setting the page title when the query has changed.

Note that this is only partially tested because I do not have my local environment set up to load data and perform queries. I was able to verify that the `setPageTitle` function can be invoked through JavaScript and that when copying/pasting the page URL from Edge, it pastes with the display text as expected.