### PR TITLE
Support crawling area-owners.json if it exists

### DIFF
--- a/scripts/area-owners-md-to-json.ps1
+++ b/scripts/area-owners-md-to-json.ps1
@@ -1,0 +1,45 @@
+$owner = "dotnet"
+$repo = "runtime"
+$markdown = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/$owner/$repo/main/docs/area-owners.md").Content -Split "\n"
+
+Function Parse-LabelLine {
+    param ([String]$line)
+
+    $cols = $line -split "\|"
+
+    $label = $cols[1].Trim()
+    $lead = $cols[2].Trim().Replace("@", "")
+    $owners = $cols[3].Trim().Replace("@", "").Replace(",", "") -split " "
+
+    $people = $owners -notmatch "$owner/"
+    $teams = $owners -match "$owner/"
+    $teamMembers = @()
+
+    foreach ($team in $teams) {
+        $teamParts = $team -split "/"
+        $org = $teamParts[0]
+        $teamName = $teamParts[1]
+
+        Write-Host "Loading members of team $org/$teamName"
+
+        try {
+            $teamMembers = (gh api orgs/$org/teams/$teamName/members | ConvertFrom-Json).login
+        }
+        catch {
+            Write-Host "Could not load team members for $org/$teamName"
+        }
+    }
+
+    @{
+        label = [String]$label;
+        lead = [String]$lead;
+        owners = [String[]](($people + $teamMembers) | Sort-Object -Unique)
+    }
+}
+
+[Object[]]$areas = ($markdown | Select-String -Pattern "^\|\s*area-").Line | Foreach-Object -Process {Parse-LabelLine $_}
+[Object[]]$operatingSystems = ($markdown | Select-String -Pattern "^\|\s*os-").Line | Foreach-Object -Process {Parse-LabelLine $_}
+[Object[]]$architectures = ($markdown | Select-String -Pattern "^\|\s*arch-").Line | Foreach-Object -Process {Parse-LabelLine $_}
+
+$data = @{ areas = $areas; operatingSystems = $operatingSystems; architectures = $architectures }
+$data | ConvertTo-Json -Depth 5 > area-owners.json

--- a/src/IssueDb/Crawling/CrawledAreaOwnerFile.cs
+++ b/src/IssueDb/Crawling/CrawledAreaOwnerFile.cs
@@ -5,7 +5,9 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
+using IssueDb.Crawling;
 
 namespace IssueDb
 {
@@ -21,25 +23,51 @@ namespace IssueDb
         public static async Task<CrawledAreaOwnerFile> GetAsync(string org, string repo)
         {
             var maxTries = 3;
-            var url = $"https://raw.githubusercontent.com/{org}/{repo}/main/docs/area-owners.md";
+            var jsonUrl = $"https://raw.githubusercontent.com/{org}/{repo}/main/docs/area-owners.json";
+            var markdownUrl = $"https://raw.githubusercontent.com/{org}/{repo}/main/docs/area-owners.md";
+            var jsonFileNotFound = false;
 
             while (maxTries-- > 0)
             {
                 var client = new HttpClient();
-                try
+
+                if (!jsonFileNotFound)
                 {
-                    var contents = await client.GetStringAsync(url);
-                    return Parse(contents);
+                    try
+                    {
+                        // First attempt to load a JSON file
+                        var jsonEntries = await client.GetFromJsonAsync<CrawledAreaOwnerJsonFile>(jsonUrl);
+                        return new CrawledAreaOwnerFile(jsonEntries.Areas.Select(area => new CrawledAreaOwnerEntry(area.Label, area.Lead, area.Owners)));
+                    }
+                    catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        // If the JSON file was not found, fall back to trying to load the Markdown file
+                        jsonFileNotFound = true;
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        // This might be a transient error; log it and continue
+                        Debug.WriteLine(ex);
+                    }
                 }
-                catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+
+                if (jsonFileNotFound)
                 {
-                    // In this case we know that the file doesn't exist.
-                    return null;
-                }
-                catch (HttpRequestException ex)
-                {
-                    // This might be a transient error.
-                    Debug.WriteLine(ex);
+                    try
+                    {
+                        var contents = await client.GetStringAsync(markdownUrl);
+                        return Parse(contents);
+                    }
+                    catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        // Neither the JSON nor MD files could be found; there's no area owner file
+                        return null;
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        // This might be a transient error.
+                        Debug.WriteLine(ex);
+                    }
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/IssueDb/Crawling/CrawledAreaOwnerFile.cs
+++ b/src/IssueDb/Crawling/CrawledAreaOwnerFile.cs
@@ -37,7 +37,7 @@ namespace IssueDb
                     {
                         // First attempt to load a JSON file
                         var jsonEntries = await client.GetFromJsonAsync<CrawledAreaOwnerJsonFile>(jsonUrl);
-                        return new CrawledAreaOwnerFile(jsonEntries.Areas.Select(area => new CrawledAreaOwnerEntry(area.Label, area.Lead, area.Owners)));
+                        return new CrawledAreaOwnerFile(jsonEntries.Areas.Select(area => new CrawledAreaOwnerEntry(area.Label.Replace("area-", ""), area.Lead, area.Owners)));
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                     {

--- a/src/IssueDb/Crawling/CrawledAreaOwnerJsonEntry.cs
+++ b/src/IssueDb/Crawling/CrawledAreaOwnerJsonEntry.cs
@@ -1,0 +1,16 @@
+﻿namespace IssueDb.Crawling
+{
+    public sealed class CrawledAreaOwnerJsonEntry
+    {
+        public string Label { get; }
+        public string Lead { get; }
+        public string[] Owners { get; }
+
+        public CrawledAreaOwnerJsonEntry(string label, string lead, string[] owners)
+        {
+            Label = label;
+            Lead = lead;
+            Owners = owners;
+        }
+    }
+}

--- a/src/IssueDb/Crawling/CrawledAreaOwnerJsonFile.cs
+++ b/src/IssueDb/Crawling/CrawledAreaOwnerJsonFile.cs
@@ -1,0 +1,16 @@
+﻿namespace IssueDb.Crawling
+{
+    public sealed class CrawledAreaOwnerJsonFile
+    {
+        public CrawledAreaOwnerJsonEntry[] Areas { get; }
+        public CrawledAreaOwnerJsonEntry[] OperatingSystems { get; }
+        public CrawledAreaOwnerJsonEntry[] Architectures { get; }
+
+        public CrawledAreaOwnerJsonFile(CrawledAreaOwnerJsonEntry[] areas, CrawledAreaOwnerJsonEntry[] operatingSystems, CrawledAreaOwnerJsonEntry[] architectures)
+        {
+            Areas = areas;
+            OperatingSystems = operatingSystems;
+            Architectures = architectures;
+        }
+    }
+}


### PR DESCRIPTION
Along with the crawling functionality, this PR includes a utility script that will download an area-owners.md file and produce an area-owners.json file, expanding GitHub team members found to be owners.