### PR TITLE
Retain team names in the list of area owners

### DIFF
--- a/scripts/area-owners-md-to-json.ps1
+++ b/scripts/area-owners-md-to-json.ps1
@@ -33,7 +33,7 @@ Function Parse-LabelLine {
     @{
         label = [String]$label;
         lead = [String]$lead;
-        owners = [String[]](($people + $teamMembers) | Sort-Object -Unique)
+        owners = [String[]]((($people + $teamMembers) | Sort-Object -Unique) + $teams)
     }
 }
 


### PR DESCRIPTION
This just updates the script for converting from markdown to JSON.