### PR TITLE
Track expanded groups by a unique id string rather than by object reference

### DIFF
--- a/src/IssueDb/Crawling/CrawledIssueGroup.cs
+++ b/src/IssueDb/Crawling/CrawledIssueGroup.cs
@@ -5,10 +5,12 @@
         public CrawledIssueGroup(string[] keys, CrawledIssueOrGroup[] children)
         {
             Keys = keys;
+            UniqueId = string.Join(',', keys);
             Children = children;
         }
 
         public string[] Keys { get; }
+        public string UniqueId { get; }
         public CrawledIssueOrGroup[] Children { get; }
     }
 }

--- a/src/IssueDb/Crawling/CrawledIssueResults.GroupedIssueResults.cs
+++ b/src/IssueDb/Crawling/CrawledIssueResults.GroupedIssueResults.cs
@@ -12,7 +12,7 @@ namespace IssueDb.Crawling
             private readonly IReadOnlyCollection<IssueSort> _sorts;
             private readonly CrawledIssueGroupKey[] _keys;
             private readonly CrawledIssueGroup[] _groups;
-            private readonly HashSet<CrawledIssueGroup> _expandedGroups = new HashSet<CrawledIssueGroup>();
+            private readonly HashSet<string> _expandedGroups = new HashSet<string>();
             private int _itemCount;
             private int _issueCount;
 
@@ -34,7 +34,7 @@ namespace IssueDb.Crawling
 
             public override IEnumerable<CrawledIssueOrGroup> Roots => _groups.Select(g => (CrawledIssueOrGroup)g);
 
-            public override bool IsExpanded(CrawledIssueGroup group) => _expandedGroups.Contains(group);
+            public override bool IsExpanded(CrawledIssueGroup group) => _expandedGroups.Contains(group.UniqueId);
 
             public override void ExpandAll()
             {
@@ -45,7 +45,7 @@ namespace IssueDb.Crawling
 
                 void Walk(CrawledIssueGroup group)
                 {
-                    _expandedGroups.Add(group);
+                    _expandedGroups.Add(group.UniqueId);
 
                     foreach (var child in group.Children)
                     {
@@ -63,13 +63,13 @@ namespace IssueDb.Crawling
 
             public override void Expand(CrawledIssueGroup group)
             {
-                _expandedGroups.Add(group);
+                _expandedGroups.Add(group.UniqueId);
                 UpdateCounts();
             }
 
             public override void Collapse(CrawledIssueGroup group)
             {
-                _expandedGroups.Remove(group);
+                _expandedGroups.Remove(group.UniqueId);
                 UpdateCounts();
             }
 
@@ -122,7 +122,7 @@ namespace IssueDb.Crawling
 
                 return result;
 
-                static void Walk(List<CrawledIssueOrGroup> result, HashSet<CrawledIssueGroup> expandedGroups, CrawledIssueGroup parent, CrawledIssueOrGroup item, ref int itemsToSkip)
+                static void Walk(List<CrawledIssueOrGroup> result, HashSet<string> expandedGroups, CrawledIssueGroup parent, CrawledIssueOrGroup item, ref int itemsToSkip)
                 {
                     if (result.Count == ItemsPerPage)
                         return;
@@ -144,7 +144,7 @@ namespace IssueDb.Crawling
                     {
                         var group = item.ToGroup();
 
-                        if (expandedGroups.Contains(group))
+                        if (expandedGroups.Contains(group.UniqueId))
                         {
                             foreach (var child in group.Children)
                                 Walk(result, expandedGroups, group, child, ref itemsToSkip);


### PR DESCRIPTION
Fixes #19

I cannot run the application locally to verify my diagnosis or fix, but I suspect the root cause is that expanded groups are being tracked by references to group objects, which are then not equal on subsequent renders. This change tracks expanded groups by a string representation of the group's keys, which should then be equal upon rerendering.