### PR TITLE
change page from 25 to 100 results

### DIFF
--- a/src/IssueDb/Crawling/CrawledIssueResults.cs
+++ b/src/IssueDb/Crawling/CrawledIssueResults.cs
@@ -8,7 +8,7 @@ namespace IssueDb.Crawling
 {
     public abstract partial class CrawledIssueResults
     {
-        protected const int ItemsPerPage = 50;
+        protected const int ItemsPerPage = 100;
 
         public int PageCount => (int)Math.Ceiling(ItemCount / (float)ItemsPerPage);
 

--- a/src/IssueDb/Crawling/CrawledIssueResults.cs
+++ b/src/IssueDb/Crawling/CrawledIssueResults.cs
@@ -8,7 +8,7 @@ namespace IssueDb.Crawling
 {
     public abstract partial class CrawledIssueResults
     {
-        protected const int ItemsPerPage = 25;
+        protected const int ItemsPerPage = 50;
 
         public int PageCount => (int)Math.Ceiling(ItemCount / (float)ItemsPerPage);
 


### PR DESCRIPTION
* Fewer pages requested from server
* Ctrl-F is possible through the list
* Can page-up and page-down

I don't know why Github limits to 25 but there seems no good reason. I would actually prefer "nearly infinite" eg 250 but 50 would be an improvement.

@terrajobst